### PR TITLE
Revise secondsToImpact computation

### DIFF
--- a/RasterPropMonitor/Core/PropMonitorComputer.cs
+++ b/RasterPropMonitor/Core/PropMonitorComputer.cs
@@ -265,10 +265,11 @@ namespace JSI
 				double accelUp = Vector3d.Dot(vessel.acceleration, up);
 
 				double altitude = altitudeTrue;
-				if(vessel.mainBody.ocean)
+				if (vessel.mainBody.ocean && altitudeASL > 0.0)
 				{
 					// AltitudeTrue shows distance above the floor of the ocean,
-					// so use ASL if it's closer in this case.
+					// so use ASL if it's closer in this case, and we're not
+					// already below SL.
 					altitude = Math.Min(altitudeASL, altitudeTrue);
 				}
 


### PR DESCRIPTION
This computation accounts for oceans by selecting the smaller of ASL or true altitude when mainBody has oceans and ASL is positive (to account for submarines).  It also uses the vertical component of vessel acceleration when the vessel is moving down and the acceleration is downward.  The latter provides a tidy way to handle powered descents and parachutes.
