### PR TITLE
Account for camera position when setting up target icon position.

### DIFF
--- a/RasterPropMonitor/Core/FlyingCamera.cs
+++ b/RasterPropMonitor/Core/FlyingCamera.cs
@@ -112,6 +112,11 @@ namespace JSI
 			return rotation * offset;
 		}
 
+		public Transform GetTransform()
+		{
+			return cameraTransform.transform;
+		}
+
 		public bool Render(float yawOffset = 0.0f, float pitchOffset = 0.0f)
 		{
 			if (!enabled)

--- a/RasterPropMonitor/Handlers/JSISteerableCamera.cs
+++ b/RasterPropMonitor/Handlers/JSISteerableCamera.cs
@@ -133,7 +133,7 @@ namespace JSI
 				if (gizmoTexture != null && target!=null && showTargetIcon)
 				{
 					// Figure out which direction the target is.
-					Vector3 targetDisplacement = target.GetTransform().position - vessel.GetTransform().position;
+					Vector3 targetDisplacement = target.GetTransform().position - cameraObject.GetTransform().position;
 					targetDisplacement.Normalize();
 
 					// Transform it using the active camera's rotation.


### PR DESCRIPTION
I didn't check closely enough with a camera displaced from the centerline.  Now the camera position and the target part position are accounted for.
