### PR TITLE
Fix HUD failure to render when an invalid camera transform is supplied.

### DIFF
--- a/RasterPropMonitor/Handlers/JSIHeadsUpDisplay.cs
+++ b/RasterPropMonitor/Handlers/JSIHeadsUpDisplay.cs
@@ -98,8 +98,8 @@ namespace JSI
 			}
 
 			// Draw the camera's view, if configured.
-			if (cameraObject != null && !cameraObject.Render()) {
-				return false;
+			if (cameraObject != null) {
+				cameraObject.Render();
 			}
 
 			// Figure out the texture coordinate scaling for the ladder.


### PR DESCRIPTION
cameraObject.Render() returns false legitimately if a bad transform is supplied.
