### PR TITLE
Change DrawOrbit to use double precision instead of single for segments.

### DIFF
--- a/RasterPropMonitor/Handlers/JSIOrbitDisplay.cs
+++ b/RasterPropMonitor/Handlers/JSIOrbitDisplay.cs
@@ -74,8 +74,8 @@ namespace JSI
 
 		private static void DrawOrbit(Orbit o, double startUT, double endUT, Matrix4x4 screenTransform, int numSegments)
 		{
-			float dT = (float)(endUT - startUT) / (float)numSegments;
-			float t = (float)startUT;
+			double dT = (endUT - startUT) / (double)numSegments;
+			double t = startUT;
 
 			Vector3 lastVertex = screenTransform.MultiplyPoint3x4(o.SwappedRelativePositionAtUT(t));
 			for (int i = 0; i < numSegments; ++i) {


### PR DESCRIPTION
This handles the problem of single precision that shows up close to UT year 10.
