### PR TITLE
Fix Rendezvous Autopilot to point at the rendezvous AP instead of dock...

### DIFF
--- a/MechJebRPM/MechJebRPMButtons.cs
+++ b/MechJebRPM/MechJebRPMButtons.cs
@@ -434,23 +434,18 @@ namespace MechJebRPM
 			if (activeJeb == null) {
 				return;
 			}
-			var autopilot = activeJeb.GetComputerModule<MechJebModuleDockingAutopilot>();
-			if (autopilot != null) {
-				var autopilotController = activeJeb.GetComputerModule<MechJebModuleDockingGuidance>();
+			var autopilot = activeJeb.GetComputerModule<MechJebModuleRendezvousAutopilot>();
+			if (autopilot != null && activeJeb.target.NormalTargetExists && activeJeb.target.Orbit.referenceBody == vessel.orbit.referenceBody) {
+				/*
+				var autopilotController = activeJeb.GetComputerModule<MechJebModuleRendezvousAutopilotWindow>();
 				if (autopilotController != null && autopilot.enabled != state) {
-					// Do some cursory validation like the "real" controller:
-					if (!(activeJeb.target.Target is ModuleDockingNode)) {
-						return; // Must target docking port
-					}
-					if (autopilot.speedLimit < 0) {
-						autopilot.speedLimit = 0;
-					}
 					if (state) {
 						autopilot.users.Add(autopilotController);
 					} else {
 						autopilot.users.Remove(autopilotController);
 					}
 				}
+				 */
 			}
 		}
 
@@ -464,7 +459,7 @@ namespace MechJebRPM
 			if (activeJeb == null) {
 				return false;
 			}
-			var autopilot = activeJeb.GetComputerModule<MechJebModuleDockingAutopilot>();
+			var autopilot = activeJeb.GetComputerModule<MechJebModuleRendezvousAutopilot>();
 			return (autopilot != null && autopilot.enabled);
 		}
 


### PR DESCRIPTION
... AP.

However, since the RAP window is not public in MJ, we can't actually use it, so the button is currently a no-op.

Button state, however, should work just fine.  Once a MJ build is released with the controller exposed, it should be trivial to switch this on.
