### PR TITLE
Improve min distance computation

### DIFF
--- a/RasterPropMonitor/Core/MathExtensions.cs
+++ b/RasterPropMonitor/Core/MathExtensions.cs
@@ -11,7 +11,7 @@ namespace JSI
 			return new Vector3d(Math.Sign(vector.x), Math.Sign(vector.y), Math.Sign(vector.z));
 		}
 
-		public static Vector3d Reorder(this Vector3d vector, int order)
+		/*public static Vector3d Reorder(this Vector3d vector, int order)
 		{
 			switch (order) {
 				case 123:
@@ -28,7 +28,7 @@ namespace JSI
 					return new Vector3d(vector.z, vector.y, vector.x);
 			}
 			throw new ArgumentException("Invalid order", "order");
-		}
+		}*/
 
 		public static Vector3d Invert(this Vector3d vector)
 		{

--- a/RasterPropMonitor/Core/OrbitExtensions.cs
+++ b/RasterPropMonitor/Core/OrbitExtensions.cs
@@ -5,24 +5,18 @@ namespace JSI
 	// This entire class is imported wholesale from MechJeb.
 	public static class OrbitExtensions
 	{
-		//can probably be replaced with Vector3d.xzy?
-		public static Vector3d SwapYZ(Vector3d v)
-		{
-			return v.Reorder(132);
-		}
-		//
 		// These "Swapped" functions translate preexisting Orbit class functions into world
 		// space. For some reason, Orbit class functions seem to use a coordinate system
 		// in which the Y and Z coordinates are swapped.
 		//
 		public static Vector3d SwappedOrbitalVelocityAtUT(this Orbit o, double UT)
 		{
-			return SwapYZ(o.getOrbitalVelocityAtUT(UT));
+			return o.getOrbitalVelocityAtUT(UT).xzy;
 		}
 		//position relative to the primary
 		public static Vector3d SwappedRelativePositionAtUT(this Orbit o, double UT)
 		{
-			return SwapYZ(o.getRelativePositionAtUT(UT));
+			return o.getRelativePositionAtUT(UT).xzy;
 		}
 		//position in world space
 		public static Vector3d SwappedAbsolutePositionAtUT(this Orbit o, double UT)
@@ -33,7 +27,7 @@ namespace JSI
 		//convention: as you look down along the orbit normal, the satellite revolves counterclockwise
 		public static Vector3d SwappedOrbitNormal(this Orbit o)
 		{
-			return -SwapYZ(o.GetOrbitNormal()).normalized;
+			return -(o.GetOrbitNormal().xzy).normalized;
 		}
 		//normalized vector along the orbital velocity
 		public static Vector3d Prograde(this Orbit o, double UT)
@@ -246,7 +240,7 @@ namespace JSI
 		public static double TrueAnomalyFromVector(this Orbit o, Vector3d vec)
 		{
 			Vector3d projected = Vector3d.Exclude(o.SwappedOrbitNormal(), vec);
-			Vector3d vectorToPe = SwapYZ(o.eccVec);
+			Vector3d vectorToPe = o.eccVec.xzy;
 			double angleFromPe = Math.Abs(Vector3d.Angle(vectorToPe, projected));
 
 			//If the vector points to the infalling part of the orbit then we need to do 360 minus the

--- a/RasterPropMonitor/Core/UtilityFunctions.cs
+++ b/RasterPropMonitor/Core/UtilityFunctions.cs
@@ -542,7 +542,7 @@ namespace JSI
 		public static Orbit OrbitFromStateVectors(Vector3d pos, Vector3d vel, CelestialBody body, double UT)
 		{
 			Orbit ret = new Orbit();
-			ret.UpdateFromStateVectors(OrbitExtensions.SwapYZ(pos - body.position), OrbitExtensions.SwapYZ(vel), body, UT);
+			ret.UpdateFromStateVectors((pos - body.position).xzy, vel.xzy, body, UT);
 			return ret;
 		}
 

--- a/RasterPropMonitor/Handlers/JSIOrbitDisplay.cs
+++ b/RasterPropMonitor/Handlers/JSIOrbitDisplay.cs
@@ -97,13 +97,13 @@ namespace JSI
 			double dTheta = (endTA - startTA) / (double)numSegments;
 			double theta = startTA;
 			double timeAtTA = o.GetUTforTrueAnomaly(theta, now);
-			Vector3 lastVertex = screenTransform.MultiplyPoint3x4(OrbitExtensions.SwapYZ(o.getRelativePositionFromTrueAnomaly(theta)) + (o.referenceBody.getTruePositionAtUT(timeAtTA)) - (referenceBody.getTruePositionAtUT(timeAtTA)));
+			Vector3 lastVertex = screenTransform.MultiplyPoint3x4(o.getRelativePositionFromTrueAnomaly(theta).xzy + (o.referenceBody.getTruePositionAtUT(timeAtTA)) - (referenceBody.getTruePositionAtUT(timeAtTA)));
 			for (int i = 0; i < numSegments; ++i) {
 				GL.Vertex3(lastVertex.x, lastVertex.y, 0.0f);
 				theta += dTheta;
 				timeAtTA = o.GetUTforTrueAnomaly(theta, now);
 
-				Vector3 newVertex = screenTransform.MultiplyPoint3x4(OrbitExtensions.SwapYZ(o.getRelativePositionFromTrueAnomaly(theta)) + (o.referenceBody.getTruePositionAtUT(timeAtTA)) - (referenceBody.getTruePositionAtUT(timeAtTA)));
+				Vector3 newVertex = screenTransform.MultiplyPoint3x4(o.getRelativePositionFromTrueAnomaly(theta).xzy + (o.referenceBody.getTruePositionAtUT(timeAtTA)) - (referenceBody.getTruePositionAtUT(timeAtTA)));
 				GL.Vertex3(newVertex.x, newVertex.y, 0.0f);
 
 				lastVertex = newVertex;
@@ -123,13 +123,13 @@ namespace JSI
 			double theta = 0.0;
 			double now = Planetarium.GetUniversalTime();
 			double timeAtTA = o.GetUTforTrueAnomaly(theta, now);
-			Vector3 lastVertex = screenTransform.MultiplyPoint3x4(OrbitExtensions.SwapYZ(o.getRelativePositionFromTrueAnomaly(theta)) + (o.referenceBody.getTruePositionAtUT(timeAtTA)) - (referenceBody.getTruePositionAtUT(timeAtTA)));
+			Vector3 lastVertex = screenTransform.MultiplyPoint3x4(o.getRelativePositionFromTrueAnomaly(theta).xzy + (o.referenceBody.getTruePositionAtUT(timeAtTA)) - (referenceBody.getTruePositionAtUT(timeAtTA)));
 			for (int i = 0; i < numSegments; ++i) {
 				GL.Vertex3(lastVertex.x, lastVertex.y, 0.0f);
 				theta += dTheta;
 				timeAtTA = o.GetUTforTrueAnomaly(theta, now);
 
-				Vector3 newVertex = screenTransform.MultiplyPoint3x4(OrbitExtensions.SwapYZ(o.getRelativePositionFromTrueAnomaly(theta)) + (o.referenceBody.getTruePositionAtUT(timeAtTA)) - (referenceBody.getTruePositionAtUT(timeAtTA)));
+				Vector3 newVertex = screenTransform.MultiplyPoint3x4(o.getRelativePositionFromTrueAnomaly(theta).xzy + (o.referenceBody.getTruePositionAtUT(timeAtTA)) - (referenceBody.getTruePositionAtUT(timeAtTA)));
 				GL.Vertex3(newVertex.x, newVertex.y, 0.0f);
 
 				lastVertex = newVertex;


### PR DESCRIPTION
And eliminate the compound call used to reorder the yz components of a vec3 - there is a method/accessor in Vector3 (.xzy) that does the swap without the need for additional function calls and switches.
