### PR TITLE
Update Force Roll string in the MJ menu.

### DIFF
--- a/MechJebRPM/MechJebRPM.cs
+++ b/MechJebRPM/MechJebRPM.cs
@@ -230,7 +230,7 @@ namespace MechJebRPM
 			targetMenuItem.isDisabled = (FlightGlobals.fetch.VesselTarget == null);
 			nodeMenuItem.isDisabled = (vessel.patchedConicSolver.maneuverNodes.Count == 0);
 			// Analysis disable once RedundantCast
-			forceRollMenuItem.labelText = String.Format("Force Roll - {0:f0}", (double)activeSmartass.rol);
+			forceRollMenuItem.labelText = String.Format("Force Roll: {0:+0;-0;0}", (double)activeSmartass.rol);
 
 			// MOARdV:
 			// This is a little messy, since SmartASS can be updated


### PR DESCRIPTION
Now explicitly shows sign for +/- values, and replaces the hyphen with a colon for clarity.
