### PR TITLE
Prevent a divide-by-zero in effective throttle computations.

### DIFF
--- a/RasterPropMonitor/Core/PropMonitorComputer.cs
+++ b/RasterPropMonitor/Core/PropMonitorComputer.cs
@@ -1416,7 +1416,7 @@ namespace JSI
 				case "HOVERPOINTEXISTS":
 					return (localGeeDirect / (totalMaximumThrust / totalShipWetMass)) > 1 ? -1d : 1d;
 				case "EFFECTIVETHROTTLE":
-					return totalCurrentThrust / totalMaximumThrust;
+					return (totalMaximumThrust > 0.0) ? (totalCurrentThrust / totalMaximumThrust) : 0.0;
 
 			// Maneuvers
 				case "MNODETIMESECS":


### PR DESCRIPTION
There's not a good reason for a NaN to be a valid answer if there's no thrust.
