### PR TITLE
Make sure anyone who uses GL drawing primitives directly resets GL.Color...

### DIFF
--- a/RasterPropMonitor/Handlers/JSIOrbitDisplay.cs
+++ b/RasterPropMonitor/Handlers/JSIOrbitDisplay.cs
@@ -438,7 +438,8 @@ namespace JSI
 			GL.Color(orbitColorSelfValue);
 			DrawOrbit(vessel.orbit, vessel.orbit.referenceBody, screenTransform, orbitPoints);
 
-			// Done drawing lines.
+			// Done drawing lines.  Reset color to white, so we don't mess up anyone else.
+			GL.Color(Color.white);
 			GL.End();
 
 			// Draw target vessel icons.

--- a/RasterPropMonitor/Handlers/JSIVariableGraph.cs
+++ b/RasterPropMonitor/Handlers/JSIVariableGraph.cs
@@ -208,6 +208,8 @@ namespace JSI
 					GL.Vertex(end);
 					start = end;
 				}
+				// Reset color to white.
+				GL.Color(Color.white);
 				GL.End();
 			}
 		}


### PR DESCRIPTION
... to white

Unity doesn't consistently reset the color state, and it causes glitches on drawing.  Reported in the KSO thread.  It's not clear to me why the bug is inconsistent, but it's trivial to add the GL.Color as the last step before exiting GL primitive drawing mode.  We may consider adding GL.Color(white) to the beginning of the other pages that use texture/icon drawing, as extra insurance.
