### PR TITLE
Changed the way relative velocities are calculated for docking.

### DIFF
--- a/RasterPropMonitor/Core/PropMonitorComputer.cs
+++ b/RasterPropMonitor/Core/PropMonitorComputer.cs
@@ -1367,12 +1367,49 @@ namespace JSI
 					return bestPossibleSpeedAtImpact;
 
 			// The way Engineer does it...
-				case "TGTRELX":
-					return FlightGlobals.ship_tgtVelocity.x;
-				case "TGTRELY":
-					return FlightGlobals.ship_tgtVelocity.y;
-				case "TGTRELZ":
-					return FlightGlobals.ship_tgtVelocity.z;
+		//		case "TGTRELX":
+		//			return FlightGlobals.ship_tgtVelocity.x;
+		//		case "TGTRELY":
+		//			return FlightGlobals.ship_tgtVelocity.y;
+		//		case "TGTRELZ":
+		//			return FlightGlobals.ship_tgtVelocity.z;
+            
+                //The way NavyFish does it...
+                        case "TGTRELX":
+                     
+                    if (target != null)
+                    {
+                      //  if (targetDockingNode != null){
+                          Transform targetTransform = targetDockingNode.GetTransform();
+                            float normalVelocity = Vector3.Dot(FlightGlobals.ship_tgtVelocity, targetTransform.forward.normalized);
+                            Vector3 globalTransverseVelocity = FlightGlobals.ship_tgtVelocity - normalVelocity * targetTransform.forward.normalized;
+                            return Vector3.Dot(globalTransverseVelocity, FlightGlobals.ActiveVessel.ReferenceTransform.right);
+                            
+                       // }
+                    }else{
+                        return 0; 
+                    }
+
+                		case "TGTRELY":
+                    if (target != null)
+                    {
+                     //   if (targetDockingNode != null){
+                        
+                            Transform targetTransform2 = targetDockingNode.GetTransform();
+                            float normalVelocity2 = Vector3.Dot(FlightGlobals.ship_tgtVelocity, targetTransform2.forward.normalized);
+                            Vector3 globalTransverseVelocity2 = FlightGlobals.ship_tgtVelocity - normalVelocity2 * targetTransform2.forward.normalized;
+                            return Vector3.Dot(globalTransverseVelocity2, FlightGlobals.ActiveVessel.ReferenceTransform.forward);
+
+                          
+                       // }
+                    }else{
+                        return 0; 
+                    }
+                		case "TGTRELZ":
+                            //cheap way to do this one.. but should be true!
+                            return approachSpeed;
+               
+
 
 			// Time to impact. This is quite imprecise, because a precise calculation pulls in pages upon pages of MechJeb code.
 			// It accounts for gravity now, though. Pull requests welcome.


### PR DESCRIPTION
I think I improved the returned values for relative velocity components (.x, .y and .z).

Before, they were returning the relative velocities in reference to the world's x,y and z, I believe.  Which meant the numbers weren't really useful for docking.

Now they should return values relative to the docking port.  

I based all of this on the way the needle movements are calculated in NavyFish's docking port.  

I've got it compiled and working.  If you DON'T want to accept this pull, because it's breaking some way someone is already using the old numbers, I'll happily rewrite it to create new defined variables that use these calculations.  I believe these were all that was missing to make a RPM docking guidance module, which I'll work on soon!  :)  

Thanks for maintaining an awesome plugin!  :)
