### PR TITLE
Fixed Relative Angle Calculations, Added two variables

### DIFF
--- a/RasterPropMonitor/Core/PropMonitorComputer.cs
+++ b/RasterPropMonitor/Core/PropMonitorComputer.cs
@@ -1781,28 +1781,34 @@ namespace JSI
 				case "TARGETDISTANCEZ":  //closure distance from target - (h and n rcs keys)
 					return -Vector3d.Dot(targetSeparation, vessel.GetTransform().up);
 
-                case "TARGETDISTANCESCALEDX":    //scaled and clamped version of TARGETDISTANCEX.  Returns a number between 100 and -100, with precision increasing as distance decreases.
-                    double scaledX = Vector3d.Dot(targetSeparation, vessel.GetTransform().right);
-                    double zdist = -Vector3d.Dot(targetSeparation, vessel.GetTransform().up);
-                    scaledX = ((scaledX + zdist) / (zdist + zdist)) * (100) - 50;
-                    if (scaledX > 100) scaledX = 100;
-                    if (scaledX < -100) scaledX = -100;
-                    return scaledX;
+				case "TARGETDISTANCESCALEDX":    //scaled and clamped version of TARGETDISTANCEX.  Returns a number between 100 and -100, with precision increasing as distance decreases.
+					double scaledX = Vector3d.Dot(targetSeparation, vessel.GetTransform().right);
+					double zdist = -Vector3d.Dot(targetSeparation, vessel.GetTransform().up);
+					if (zdist < .1)
+						scaledX = scaledX / (0.1 * Math.Sign(zdist));
+					else
+						scaledX = ((scaledX + zdist) / (zdist + zdist)) * (100) - 50;
+					if (scaledX > 100) scaledX = 100;
+					if (scaledX < -100) scaledX = -100;
+					return scaledX;
 
 
-                case "TARGETDISTANCESCALEDY":  //scaled and clamped version of TARGETDISTANCEY.  These two numbers will control the position needles on a docking port alignment gauge.
-                    double scaledY = Vector3d.Dot(targetSeparation, vessel.GetTransform().forward);
-                    double zdist2 = -Vector3d.Dot(targetSeparation, vessel.GetTransform().up);
-                    scaledY = ((scaledY + zdist2) / (zdist2 + zdist2)) * (100) - 50;
-                    if (scaledY> 100) scaledY = 100;
-                    if (scaledY < -100) scaledY = -100;
-                    return scaledY;
+				case "TARGETDISTANCESCALEDY":  //scaled and clamped version of TARGETDISTANCEY.  These two numbers will control the position needles on a docking port alignment gauge.
+					double scaledY = Vector3d.Dot(targetSeparation, vessel.GetTransform().forward);
+					double zdist2 = -Vector3d.Dot(targetSeparation, vessel.GetTransform().up);
+					if (zdist2 < .1)
+						scaledY = scaledY / (0.1 * Math.Sign(zdist2));
+					else
+						scaledY = ((scaledY + zdist2) / (zdist2 + zdist2)) * (100) - 50;
+					if (scaledY> 100) scaledY = 100;
+					if (scaledY < -100) scaledY = -100;
+					return scaledY;
 
 			// TODO: I probably should return something else for vessels. But not sure what exactly right now.
 				case "TARGETANGLEX":
 					if (target != null) {
 						if (targetDockingNode != null)
-                            return JUtil.NormalAngle(-targetDockingNode.GetTransform().forward.normalized, FlightGlobals.ActiveVessel.ReferenceTransform.up, FlightGlobals.ActiveVessel.ReferenceTransform.forward);
+							return JUtil.NormalAngle(-targetDockingNode.GetTransform().forward, FlightGlobals.ActiveVessel.ReferenceTransform.up, FlightGlobals.ActiveVessel.ReferenceTransform.forward);
 						if (target is Vessel)
 							return JUtil.NormalAngle(-target.GetFwdVector(), forward, up);
 						return 0d;
@@ -1811,7 +1817,7 @@ namespace JSI
 				case "TARGETANGLEY":
 					if (target != null) {
 						if (targetDockingNode != null)
-                            return JUtil.NormalAngle(-targetDockingNode.GetTransform().forward.normalized, FlightGlobals.ActiveVessel.ReferenceTransform.up, -FlightGlobals.ActiveVessel.ReferenceTransform.right);
+							return JUtil.NormalAngle(-targetDockingNode.GetTransform().forward, FlightGlobals.ActiveVessel.ReferenceTransform.up, -FlightGlobals.ActiveVessel.ReferenceTransform.right);
 						if (target is Vessel) {
 							JUtil.NormalAngle(-target.GetFwdVector(), forward, -right);
 						}
@@ -1821,7 +1827,7 @@ namespace JSI
 				case "TARGETANGLEZ":
 					if (target != null) {
 						if (targetDockingNode != null)
-                            return (360 - (JUtil.NormalAngle(-targetDockingNode.GetTransform().up, FlightGlobals.ActiveVessel.ReferenceTransform.forward, FlightGlobals.ActiveVessel.ReferenceTransform.up))) % 360;
+							return (360 - (JUtil.NormalAngle(-targetDockingNode.GetTransform().up, FlightGlobals.ActiveVessel.ReferenceTransform.forward, FlightGlobals.ActiveVessel.ReferenceTransform.up))) % 360;
 						if (target is Vessel) {
 							return JUtil.NormalAngle(target.GetTransform().up, up, -forward);
 						}


### PR DESCRIPTION
This SHOULD fix any complaints about the docking angles being miscalculated.  

I also answered the comment question about what's up with the relative distance directions.

And I created two new variables that I needed to finish a docking alignment indicator:
TARGETDISTANCESCALEDX and TARGETDISTANCESCALEDY   .  These are the X and Y distances, scaled and clamped so that they always return a value between -100 and 100, and the precision increases as the distance decreases.  These numbers can be used to drive a docking port alignment gauge.  

In case it's not clear what I was trying to do, I shot a quick youtube video of all these changes thrown into a docking gauge.  It works just like NavyFish's DPAI, which is shown at the side of the screen for reference.  I did it all with JSIVariableAnimator, because I haven't wrapped my head around how to do the graphics part of drawing a background handler yet.  But you can see how the changes I've made to the rotation and velocity variables work.  It's at  - https://www.youtube.com/watch?v=EC7wNfY8AOc&feature=youtu.be

Also, I figured out how to merge the master back into my fork, so this replaces my last pull request... that was trying to remerge things that were already merged.

If you guys would prefer me to stop fiddling with your code, I understand!  I hope I'm being helpful!
