### PR TITLE
Integrated Docking Port Alignment Indicator

### DIFF
--- a/GameData/JSI/RPMPodPatches/BasicMFD/MFD40x20.cfg
+++ b/GameData/JSI/RPMPodPatches/BasicMFD/MFD40x20.cfg
@@ -469,4 +469,37 @@ PROP
 			button10 = 13
 		}
 	}
+	
+// ---- Page 'G' Docking Port Alignment Indicator (if installed)
+    PAGE
+    {
+        name = DPAI	
+        text = DPAI not installed.
+        textureURL = JSI/RasterPropMonitor/Library/Textures/bg01
+        button = button_G
+        PAGEHANDLER
+        {
+            name = DPAI_RPM
+            method = getPageText
+            buttonUp = 0
+            buttonDown = 1
+            buttonEnter = 2
+            buttonEsc = 3
+            buttonHome = 4
+            buttonRight = 5
+            buttonLeft = 6
+            buttonNext = 7
+            buttonPrev = 8
+            multiHandler = true
+        }
+        BACKGROUNDHANDLER
+        {
+            name = DPAI_RPM
+            method = DrawDPAI
+            buttonClickMethod = ButtonProcessor
+            pageActiveMethod = pageActiveMethod
+            multiHandler = true
+        }
+    }
+  }
 }

--- a/GameData/JSI/RPMPodPatches/BasicMFD/p0_home40x20.txt
+++ b/GameData/JSI/RPMPodPatches/BasicMFD/p0_home40x20.txt
@@ -1,4 +1,4 @@
-[hw]      ATT    |  GRAPH  |   TRGT   |   AUTO  |  VESSEL  |  IGNITOR  |
+[hw]      ATT    |  GRAPH  |   TRGT   |   AUTO  |  VESSEL  |  IGNITOR  |   DPAI
 
 
 


### PR DESCRIPTION
This merge will modify two files: 
-Text definition file for BasicMFD's 'home' page, adding a 'DPAI' label to the top-rightmost button
-Configuration file for MFD40x20 prop, adding a DPAI page (with default text if plugin DLL is not found)