### PR TITLE
Allow internal plugin access without a PersistenceAccessor

### DIFF
--- a/RasterPropMonitor/Core/RPMVesselComputer.cs
+++ b/RasterPropMonitor/Core/RPMVesselComputer.cs
@@ -572,7 +572,7 @@ namespace JSI
         public Delegate GetMethod(string packedMethod, InternalProp internalProp, Type delegateType)
         {
             Delegate returnValue = GetInternalMethod(packedMethod, delegateType);
-            if (returnValue == null)
+            if (returnValue == null && internalProp != null)
             {
                 returnValue = JUtil.GetMethod(packedMethod, internalProp, delegateType);
             }
@@ -1632,8 +1632,7 @@ namespace JSI
                                 }
                             }
                         }
-
-                        if (propToUse == null && persistence.prop != null)
+                        if (propToUse == null && persistence != null && persistence.prop != null)
                         {
                             //if (part.internalModel.props.Count == 0)
                             //{
@@ -1652,14 +1651,6 @@ namespace JSI
                             //}
                         }
 
-                        if (propToUse == null)
-                        {
-                            // With the refactoring, we can hit this code
-                            JUtil.LogErrorMessage(this, "Wait - propToUse is still null?");
-                            //pluginBoolVariables.Add(tokens[1], null);
-                            return -1;
-                        }
-
                         Func<bool> pluginCall = (Func<bool>)GetMethod(tokens[1], propToUse, typeof(Func<bool>));
                         if (pluginCall == null)
                         {
@@ -1673,7 +1664,12 @@ namespace JSI
                             }
                             else
                             {
-                                pluginBoolVariables.Add(tokens[1], null);
+                                // Only register the plugin variable as unavailable if we were called with persistence
+                                if (propToUse == null)
+                                {
+                                    JUtil.LogErrorMessage(this, "Tried to look for method with propToUse still null?");
+                                    pluginBoolVariables.Add(tokens[1], null);
+                                }
                                 return -1;
                             }
                         }


### PR DESCRIPTION
Trying to access a PLUGIN_XXX variable was failing if no prop/persistence instance was supplied. However, for accessing internal JSIModules (e.g. `JSIFAR`) this is not strictly required - the function (`RPMVesselComputer::GetMethod`) that does the job does not need a prop to search via `RPMVesselComputer::GetInternalMethod`.

This patch makes `GetMethod` check it's prop for null before using it further, and removes the direct check from the plugin parsing routine. It does, however, still only strike off a variable under the same circumstances - e.g. when all information including a `PersistenceAccessor` is supplied (so, matching the previous behavior).

(I encountered this whilst accessing RPM variables from outside of RPM - and having trouble finding/working out how to create a valid PersistenceAccessor, especially when one was not even needed for the information I wanted to retrieve.)