### PR TITLE
Allow remote activation of RPMVesselComputer updating?

### DIFF
--- a/RasterPropMonitor/Core/RPMVesselComputer.cs
+++ b/RasterPropMonitor/Core/RPMVesselComputer.cs
@@ -719,10 +719,6 @@ namespace JSI
                             {
                                 rpmComp = RasterPropMonitorComputer.Instantiate(part);
                             }
-                            else
-                            {
-                                JUtil.LogErrorMessage(this, "Unable to deduce the current part prior to VariableToObject.");
-                            }
                         }
 
                         returnValue = VariableToObject(input, propId, out cacheable);
@@ -862,10 +858,6 @@ namespace JSI
                         }
                     }
                 }
-            }
-            else
-            {
-                JUtil.LogMessage(this, "Not in IVA");
             }
 
             return currentPart;

--- a/RasterPropMonitor/Core/RPMVesselComputer.cs
+++ b/RasterPropMonitor/Core/RPMVesselComputer.cs
@@ -601,9 +601,14 @@ namespace JSI
 
         public void FixedUpdate()
         {
-            // FixedUpdate tracks values related to the vessel (position, CoM, etc)
             // MOARdV TODO: FixedUpdate only if in IVA?  What about transparent pods?
-            if (JUtil.VesselIsInIVA(vessel) && timeToUpdate)
+            if (JUtil.VesselIsInIVA(vessel)) UpdateVariables();
+        }
+
+        public void UpdateVariables()
+        { 
+            // Update values related to the vessel (position, CoM, etc)
+            if (timeToUpdate)
             {
 #if SHOW_FIXEDUPDATE_TIMING
                 stopwatch.Reset();


### PR DESCRIPTION
Would you consider explicitly allowing/providing a method for externally-triggered updates of the RPM variable calculations? At the moment, `FixedUpdate` can be called remotely but will early return if the user is not currently in IVA mode. Allowing this to be bypassed (e.g. the attached pull request which is the simplest I can imagine, not necessarily the cleanest - you might prefer something else) lets the update continue, still taking advantage of the caching and update-requirement checking.

The other option is to try to manually simulate the process with lots of private invoking of the `FetchXYZ` methods, with manual checking of all the private flags. But this is a horrible workaround, for which my current attempts have failed.

To expand on what I'm doing; Writing extensions to [Telemachus](https://github.com/richardbunt/Telemachus) that allows reading of RPM variables via the remote interface (my rpm reader: [here](https://github.com/ndevenish/Telemachus/blob/wsredo/Telemachus/src/Plugins/RasterPropMonitorPlugin.cs)) in order to allow external monitors/info; specifically for my usage, my [KerbalHUD](https://github.com/ndevenish/KerbalHUD) project, still WIP.