### PR TITLE
Workaround for issue #466

### DIFF
--- a/RasterPropMonitor/Core/PropMonitorComputer.cs
+++ b/RasterPropMonitor/Core/PropMonitorComputer.cs
@@ -118,6 +118,9 @@ namespace JSI
                     }
                 }
                 vesselDescriptionForDisplay = string.Join(Environment.NewLine, descriptionStrings).MangleConfigText();
+                if (string.IsNullOrEmpty(vesselDescriptionForDisplay)) {
+                    vesselDescriptionForDisplay = " "; // Workaround for issue #466.
+                }
 
                 // Now let's parse our stored strings...
                 if (!string.IsNullOrEmpty(storedStrings))


### PR DESCRIPTION
This should resolve issue #466 (VesselDescriptionWordwrapped/VesselDescriptionRaw Breaks Overlays When Description Is Empty) with minimal breakage.