### PR TITLE
Configuration fixes for the nosignal texture

### DIFF
--- a/GameData/JSI/RPMPodPatches/BasicMFD/MFD40x20.cfg
+++ b/GameData/JSI/RPMPodPatches/BasicMFD/MFD40x20.cfg
@@ -146,11 +146,11 @@ PROP
 		name = targetcam
 		button = buttonR3
 		text = JSI/RPMPodPatches/BasicMFD/p3_target40x20.txt
+		showNoSignal = true
 		BACKGROUNDHANDLER
 		{
 			name = JSISteerableCamera
 			method = RenderCamera
-			showNoSignal = yes
 			buttonClickMethod = ClickProcessor
 			buttonReleaseMethod = ReleaseProcessor
 			cameraTransform = CurrentReferenceDockingPortCamera
@@ -224,6 +224,7 @@ PROP
       name = extcamAll
       button = buttonR7
       text = Viewing ExtCam<=0=> $&$ PROP_MFDEXTCAM_ID
+	  showNoSignal = true
       
 		BACKGROUNDHANDLER
 		{
@@ -232,7 +233,6 @@ PROP
 			buttonClickMethod = ClickProcessor
 			buttonReleaseMethod = ReleaseProcessor
          cameraInfoVarName = MFDEXTCAM
-			showNoSignal = true
          skipMissingCameras = true
 			cameraTransform = ExtCam1|ExtCam2|ExtCam3|ExtCam4|ExtCam5|ExtCam6|ExtCam7|ExtCam8
 			fovLimits = 20,5|20,5|20,5|20,5|20,5|20,5|20,5|20,5

--- a/GameData/JSI/RPMPodPatches/BasicMFD/MFD40x20.cfg
+++ b/GameData/JSI/RPMPodPatches/BasicMFD/MFD40x20.cfg
@@ -224,7 +224,7 @@ PROP
       name = extcamAll
       button = buttonR7
       text = Viewing ExtCam<=0=> $&$ PROP_MFDEXTCAM_ID
-	  showNoSignal = true
+      showNoSignal = true
       
 		BACKGROUNDHANDLER
 		{


### PR DESCRIPTION
showNoSignal should be applied to pages, not backgrounds. This corrects the two camera pages to properly show the nosignal texture.

Downstream users are probably going to want to update any MFD configuration files that they derived from this one.