### PR TITLE
Add try/catch around JSIVariableLabel.Start

### DIFF
--- a/RasterPropMonitor/Core/StringProcessor.cs
+++ b/RasterPropMonitor/Core/StringProcessor.cs
@@ -37,7 +37,12 @@ namespace JSI
         // TODO: Add support for multi-line processed support.
         public StringProcessorFormatter(string input)
         {
-            if (input.IndexOf(JUtil.VariableListSeparator[0], StringComparison.Ordinal) >= 0)
+            if(string.IsNullOrEmpty(input))
+            {
+                formatString = "";
+                usesComp = false;
+            }
+            else if (input.IndexOf(JUtil.VariableListSeparator[0], StringComparison.Ordinal) >= 0)
             {
                 string[] tokens = input.Split(JUtil.VariableListSeparator, StringSplitOptions.RemoveEmptyEntries);
                 if (tokens.Length != 2)


### PR DESCRIPTION
Tell it not to access contents of the string unless the string is long
enough.  And make sure the string processor formatter handles empty
strings properly.  More Issue #506