### PR TITLE
Update mk1cockpit-remade-internal.cfg

### DIFF
--- a/GameData/JSI/RPMPodPatches/PatchesStock/mk1cockpit-remade-internal.cfg
+++ b/GameData/JSI/RPMPodPatches/PatchesStock/mk1cockpit-remade-internal.cfg
@@ -178,14 +178,14 @@ INTERNAL
 	{
 		name = Hatch_Plane
 		position = 0,0,0.14375
-		rotation = 0,1,0,-4.371139E-08
+		rotation = 0,0,0,0
 		scale = 1,1,1
 	}
 	PROP
 	{
 		name = Hatch_Plane_Curve90
 		position = 0.5327566,-0.1737644,-0.1524241
-		rotation = -0.1106159,-0.6984012,-0.1106159,0.6984012
+		rotation =0,0,0,0
 		scale = 1,1,1.000001
 	}
 	PROP


### PR DESCRIPTION
Temporarily fix the MK1 cockpit door so it no longer appears to be canted 90° with the rest of the craft.