### PR TITLE
Added a config to specify ignored parts and modules

### DIFF
--- a/RasterPropMonitor/Core/RPMGlobals.cs
+++ b/RasterPropMonitor/Core/RPMGlobals.cs
@@ -67,5 +67,10 @@ namespace JSI
         internal static List<string> knownLoadedAssemblies = new List<string>();
         internal static SortedDictionary<string, string> systemNamedResources = new SortedDictionary<string, string>();
         internal static List<RasterPropMonitorComputer.TriggeredEventTemplate> triggeredEvents = new List<RasterPropMonitorComputer.TriggeredEventTemplate>();
+
+		/// List of parts where all PartModule should be ignored.
+		internal static List<string> ignoreAllPartModules = new List<string>();
+		/// List of parts where some PartModules should be ignored.  Part names are the Key, list of module names is the Value.
+		internal static Dictionary<string, List<string>> ignorePartModules = new Dictionary<string, List<string>>();
     }
 }

--- a/RasterPropMonitor/Core/RPMVCPerModule.cs
+++ b/RasterPropMonitor/Core/RPMVCPerModule.cs
@@ -767,7 +767,8 @@ namespace JSI
             {
                 Part thatPart = availableEngines[i].part;
 
-                if (thatPart.inverseStage == StageManager.CurrentStage || !state)
+				if (StageManager.CurrentStage == StageManager.StageCount && thatPart.inverseStage == StageManager.StageCount - 1 || //This line allows to start engines of the first stage before the initial launch 
+					thatPart.inverseStage == StageManager.CurrentStage || !state)
                 {
                     if (availableEngines[i].EngineIgnited != state)
                     {

--- a/RasterPropMonitor/Core/RPMVCPerModule.cs
+++ b/RasterPropMonitor/Core/RPMVCPerModule.cs
@@ -38,6 +38,7 @@ namespace JSI
         /// JSIInternalButtons methods is outright eliminated.
 
         private bool listsInvalid = true;
+		private readonly static List<string> emptyIgnoreList = new List<string>();
 
         //--- Docking Nodes
         internal ModuleDockingNode mainDockingNode;
@@ -168,115 +169,79 @@ namespace JSI
                 var partsList = vessel.parts;
                 for (int partsIdx = 0; partsIdx < partsList.Count; ++partsIdx)
                 {
-                    foreach (PartModule module in partsList[partsIdx].Modules)
-                    {
-						if (module.isEnabled && !ShouldIgnoreModule(module))
-                        {
-                            if (module is ModuleEngines)
-                            {
-                                availableEngines.Add(module as ModuleEngines);
-                            }
-                            else if (module is MultiModeEngine)
-                            {
-                                availableMultiModeEngines.Add(module as MultiModeEngine);
-                            }
-                            else if (module is JSIThrustReverser)
-                            {
-                                availableThrustReverser.Add(module as JSIThrustReverser);
-                            }
-                            else if (module is ModuleAblator)
-                            {
-                                availableAblators.Add(module as ModuleAblator);
-                            }
-                            else if (module is ModuleResourceIntake)
-                            {
-                                if ((module as ModuleResourceIntake).resourceName == "IntakeAir")
-                                {
-                                    availableAirIntakes.Add(module as ModuleResourceIntake);
-                                }
-                                else
-                                {
-                                    JUtil.LogMessage(this, "intake resource is {0}?", (module as ModuleResourceIntake).resourceName);
-                                }
-                            }
-                            else if (module is ModuleAlternator)
-                            {
-                                ModuleAlternator alt = module as ModuleAlternator;
-                                for (int i = 0; i < alt.resHandler.outputResources.Count; ++i)
-                                {
-                                    if (alt.resHandler.outputResources[i].name == "ElectricCharge")
-                                    {
-                                        availableAlternators.Add(alt);
-                                        break;
-                                    }
-                                }
-                            }
-                            else if (module is ModuleGenerator)
-                            {
-                                ModuleGenerator gen = module as ModuleGenerator;
-                                for (int i = 0; i < gen.resHandler.outputResources.Count; ++i)
-                                {
-                                    if (gen.resHandler.outputResources[i].name == "ElectricCharge")
-                                    {
-                                        availableGenerators.Add(gen);
-                                        availableGeneratorOutput.Add((float)gen.resHandler.outputResources[i].rate);
-                                        break;
-                                    }
-                                }
-                            }
-                            else if (module is ModuleResourceConverter)
-                            {
-                                ModuleResourceConverter gen = module as ModuleResourceConverter;
-                                ConversionRecipe recipe = gen.Recipe;
-                                for (int i = 0; i < recipe.Outputs.Count; ++i)
-                                {
-                                    if (recipe.Outputs[i].ResourceName == "ElectricCharge")
-                                    {
-                                        availableFuelCells.Add(gen);
-                                        availableFuelCellOutput.Add((float)recipe.Outputs[i].Ratio);
-                                        break;
-                                    }
-                                }
-                            }
-                            else if (module is ModuleDeployableSolarPanel)
-                            {
-                                ModuleDeployableSolarPanel sp = module as ModuleDeployableSolarPanel;
+                	string partName = partsList[partsIdx].partInfo.name;
+					if (!RPMGlobals.ignoreAllPartModules.Contains(partName)) {
+						List<string> modulesToIgnore;
+						if (!RPMGlobals.ignorePartModules.TryGetValue(partName, out modulesToIgnore)) {
+							modulesToIgnore = emptyIgnoreList;
+						}
+						foreach (PartModule module in partsList[partsIdx].Modules) {
+							if (module.isEnabled && !modulesToIgnore.Contains(module.moduleName)) {
+								if (module is ModuleEngines) {
+									availableEngines.Add(module as ModuleEngines);
+								} else if (module is MultiModeEngine) {
+									availableMultiModeEngines.Add(module as MultiModeEngine);
+								} else if (module is JSIThrustReverser) {
+									availableThrustReverser.Add(module as JSIThrustReverser);
+								} else if (module is ModuleAblator) {
+									availableAblators.Add(module as ModuleAblator);
+								} else if (module is ModuleResourceIntake) {
+									if ((module as ModuleResourceIntake).resourceName == "IntakeAir") {
+										availableAirIntakes.Add(module as ModuleResourceIntake);
+									} else {
+										JUtil.LogMessage(this, "intake resource is {0}?", (module as ModuleResourceIntake).resourceName);
+									}
+								} else if (module is ModuleAlternator) {
+									ModuleAlternator alt = module as ModuleAlternator;
+									for (int i = 0; i < alt.resHandler.outputResources.Count; ++i) {
+										if (alt.resHandler.outputResources[i].name == "ElectricCharge") {
+											availableAlternators.Add(alt);
+											break;
+										}
+									}
+								} else if (module is ModuleGenerator) {
+									ModuleGenerator gen = module as ModuleGenerator;
+									for (int i = 0; i < gen.resHandler.outputResources.Count; ++i) {
+										if (gen.resHandler.outputResources[i].name == "ElectricCharge") {
+											availableGenerators.Add(gen);
+											availableGeneratorOutput.Add((float)gen.resHandler.outputResources[i].rate);
+											break;
+										}
+									}
+								} else if (module is ModuleResourceConverter) {
+									ModuleResourceConverter gen = module as ModuleResourceConverter;
+									ConversionRecipe recipe = gen.Recipe;
+									for (int i = 0; i < recipe.Outputs.Count; ++i) {
+										if (recipe.Outputs[i].ResourceName == "ElectricCharge") {
+											availableFuelCells.Add(gen);
+											availableFuelCellOutput.Add((float)recipe.Outputs[i].Ratio);
+											break;
+										}
+									}
+								} else if (module is ModuleDeployableSolarPanel) {
+									ModuleDeployableSolarPanel sp = module as ModuleDeployableSolarPanel;
 
-                                if (sp.resourceName == "ElectricCharge")
-                                {
-                                    availableSolarPanels.Add(sp);
-                                }
-                            }
-                            else if (module is ModuleGimbal)
-                            {
-                                availableGimbals.Add(module as ModuleGimbal);
-                            }
-                            else if (module is JSIRadar)
-                            {
-                                availableRadars.Add(module as JSIRadar);
-                            }
-                            else if (module is ModuleParachute)
-                            {
-                                availableParachutes.Add(module as ModuleParachute);
-                            }
-                            else if (module is ModuleWheels.ModuleWheelDeployment)
-                            {
-                                availableDeployableWheels.Add(module as ModuleWheels.ModuleWheelDeployment);
-                            }
-                            else if (module is ModuleWheels.ModuleWheelDamage)
-                            {
-                                availableWheelDamage.Add(module as ModuleWheels.ModuleWheelDamage);
-                            }
-                            else if (module is ModuleWheels.ModuleWheelBrakes)
-                            {
-                                availableWheelBrakes.Add(module as ModuleWheels.ModuleWheelBrakes);
-                            }
-                            else if (JSIParachute.rcFound && module.GetType() == JSIParachute.rcModuleRealChute)
-                            {
-                                availableRealChutes.Add(module);
-                            }
-                        }
-                    }
+									if (sp.resourceName == "ElectricCharge") {
+										availableSolarPanels.Add(sp);
+									}
+								} else if (module is ModuleGimbal) {
+									availableGimbals.Add(module as ModuleGimbal);
+								} else if (module is JSIRadar) {
+									availableRadars.Add(module as JSIRadar);
+								} else if (module is ModuleParachute) {
+									availableParachutes.Add(module as ModuleParachute);
+								} else if (module is ModuleWheels.ModuleWheelDeployment) {
+									availableDeployableWheels.Add(module as ModuleWheels.ModuleWheelDeployment);
+								} else if (module is ModuleWheels.ModuleWheelDamage) {
+									availableWheelDamage.Add(module as ModuleWheels.ModuleWheelDamage);
+								} else if (module is ModuleWheels.ModuleWheelBrakes) {
+									availableWheelBrakes.Add(module as ModuleWheels.ModuleWheelBrakes);
+								} else if (JSIParachute.rcFound && module.GetType() == JSIParachute.rcModuleRealChute) {
+									availableRealChutes.Add(module);
+								}
+							}
+						}
+					}
 
                     if (vessel.currentStage <= partsList[partsIdx].inverseStage)
                     {

--- a/RasterPropMonitor/Core/RPMVCPerModule.cs
+++ b/RasterPropMonitor/Core/RPMVCPerModule.cs
@@ -170,7 +170,7 @@ namespace JSI
                 {
                     foreach (PartModule module in partsList[partsIdx].Modules)
                     {
-                        if (module.isEnabled)
+						if (module.isEnabled && !ShouldIgnoreModule(module))
                         {
                             if (module is ModuleEngines)
                             {

--- a/RasterPropMonitor/Core/RPMVesselComputer.cs
+++ b/RasterPropMonitor/Core/RPMVesselComputer.cs
@@ -252,7 +252,6 @@ namespace JSI
         internal Vector3d velocityRelativeTarget;
         internal float approachSpeed;
         private Quaternion targetOrientation;
-		internal List<string> ignoreModuleList;
 
         #endregion
 
@@ -639,12 +638,6 @@ namespace JSI
                 }
                 //vid = vessel.id;
             }
-
-			ignoreModuleList = new List<string>();
-			ConfigNode[] ignoreNodes = GameDatabase.Instance.GetConfigNodes("RPM_IGNORE");
-			for (int node = 0; node < ignoreNodes.Length; node++) {
-				ignoreModuleList.AddRange(ignoreNodes[node].GetValuesList("moduleName"));
-			}
 
             GameEvents.onVesselChange.Add(onVesselChange);
             GameEvents.onVesselWasModified.Add(onVesselWasModified);
@@ -1445,23 +1438,6 @@ namespace JSI
         }
 
 		/// <summary>
-		/// Determines if partModule is listed in RPM_IGNORE by either "moduleName = ItsPartName.*" or "moduleName = ItsPartName.TheModuleName".
-		/// </summary>
-		/// <returns>true if the module is specified to be ignored</returns>
-		internal bool ShouldIgnoreModule(PartModule partModule) {
-			if (ignoreModuleList.Count == 0) {
-				return false;
-			}
-			//Pod part names have a vessel name added to them after a whitespace, we have to get rid of it
-			int vesselNameIndex = -1;
-			if (partModule.part.name.Length > partModule.vessel.vesselName.Length) { //Extra comparison to skip one string operation
-				vesselNameIndex = partModule.part.name.IndexOf(" (" + partModule.vessel.vesselName);
-			}
-			string partName = (vesselNameIndex < 0 ? partModule.part.name : partModule.part.name.Substring(0, vesselNameIndex));
-			return ignoreModuleList.Contains(partName + ".*") || ignoreModuleList.Contains(partName + "." + partModule.moduleName);
-		}
-
-        /// <summary>
         /// Determines if enough screen updates have passed to trigger another data update.
         /// </summary>
         /// <returns>true if it's time to update things</returns>

--- a/RasterPropMonitor/Core/RPMVesselComputer.cs
+++ b/RasterPropMonitor/Core/RPMVesselComputer.cs
@@ -252,6 +252,7 @@ namespace JSI
         internal Vector3d velocityRelativeTarget;
         internal float approachSpeed;
         private Quaternion targetOrientation;
+		internal List<string> ignoreModuleList;
 
         #endregion
 
@@ -638,6 +639,13 @@ namespace JSI
                 }
                 //vid = vessel.id;
             }
+
+			ignoreModuleList = new List<string>();
+			ConfigNode[] ignoreNodes = GameDatabase.Instance.GetConfigNodes("RPM_IGNORE");
+			for (int node = 0; node < ignoreNodes.Length; node++) {
+				ignoreModuleList.AddRange(ignoreNodes[node].GetValuesList("moduleName"));
+			}
+
             GameEvents.onVesselChange.Add(onVesselChange);
             GameEvents.onVesselWasModified.Add(onVesselWasModified);
             GameEvents.onStageActivate.Add(onStageActivate);
@@ -1435,6 +1443,20 @@ namespace JSI
             }
             return impactTime - decelTime / 2.0 - Planetarium.GetUniversalTime();
         }
+
+		/// <summary>
+		/// Determines if partModule is listed in RPM_IGNORE by either "moduleName = ItsPartName.*" or "moduleName = ItsPartName.TheModuleName".
+		/// </summary>
+		/// <returns>true if the module is specified to be ignored</returns>
+		internal bool ShouldIgnoreModule(PartModule partModule) {
+			//Pod part names have a vessel name added to them after a whitespace, we have to get rid of it
+			int vesselNameIndex = -1;
+			if (partModule.part.name.Length > partModule.vessel.vesselName.Length) { //Extra comparison to skip one string operation
+				vesselNameIndex = partModule.part.name.IndexOf(" (" + partModule.vessel.vesselName);
+			}
+			string partName = vesselNameIndex < 0 ? partModule.part.name : partModule.part.name.Substring(0, vesselNameIndex);
+			return ignoreModuleList.Contains(partName + ".*") || ignoreModuleList.Contains(partName + "." + partModule.moduleName);
+		}
 
         /// <summary>
         /// Determines if enough screen updates have passed to trigger another data update.

--- a/RasterPropMonitor/Core/RPMVesselComputer.cs
+++ b/RasterPropMonitor/Core/RPMVesselComputer.cs
@@ -1449,12 +1449,15 @@ namespace JSI
 		/// </summary>
 		/// <returns>true if the module is specified to be ignored</returns>
 		internal bool ShouldIgnoreModule(PartModule partModule) {
+			if (ignoreModuleList.Count == 0) {
+				return false;
+			}
 			//Pod part names have a vessel name added to them after a whitespace, we have to get rid of it
 			int vesselNameIndex = -1;
 			if (partModule.part.name.Length > partModule.vessel.vesselName.Length) { //Extra comparison to skip one string operation
 				vesselNameIndex = partModule.part.name.IndexOf(" (" + partModule.vessel.vesselName);
 			}
-			string partName = vesselNameIndex < 0 ? partModule.part.name : partModule.part.name.Substring(0, vesselNameIndex);
+			string partName = (vesselNameIndex < 0 ? partModule.part.name : partModule.part.name.Substring(0, vesselNameIndex));
 			return ignoreModuleList.Contains(partName + ".*") || ignoreModuleList.Contains(partName + "." + partModule.moduleName);
 		}
 

--- a/RasterPropMonitor/Core/UtilityFunctions.cs
+++ b/RasterPropMonitor/Core/UtilityFunctions.cs
@@ -2034,6 +2034,31 @@ namespace JSI
                 }
             }
 
+			RPMGlobals.ignoreAllPartModules.Clear();
+			RPMGlobals.ignorePartModules.Clear();
+			nodes = GameDatabase.Instance.GetConfigNodes("RPM_IGNORE_MODULES");
+			for (int idx = 0; idx < nodes.Length; ++idx) {
+				foreach (string nameExpression in nodes[idx].GetValuesList("moduleName")) {
+					string[] splitted = nameExpression.Split(':'); //splitted[0] - part name, splitted[1] - module name
+					if (splitted.Length != 2 || splitted[0].Length == 0 || splitted[1].Length == 0) {
+						continue; //just skipping in case of bad syntax
+					}
+					string partName = splitted[0].Replace('_','.'); //KSP does it, so we do
+					if (splitted[1] == "*") {
+						RPMGlobals.ignoreAllPartModules.Add(partName);
+					} else {
+						List<string> moduleNameList;
+						if (!RPMGlobals.ignorePartModules.TryGetValue(partName, out moduleNameList)) {
+							moduleNameList = new List<string>();
+							RPMGlobals.ignorePartModules.Add(partName, moduleNameList);
+						}
+						if (!moduleNameList.Contains(splitted[1])) {
+							moduleNameList.Add(splitted[1]);
+						}
+					}
+				}
+			}
+
             RPMGlobals.knownLoadedAssemblies.Clear();
             for (int i = 0; i < AssemblyLoader.loadedAssemblies.Count; ++i)
             {


### PR DESCRIPTION
Enables to specify ignored part modules as a plain config as RPM_IGNORE node with values following the syntax:

```
RPM_IGNORE
{
     //Ignore all of the PartModules of a part with name "MyPartName":
     moduleName = MyPartName.*

     //Ignore only a PartModule with name "TheModuleName" of a part with name "MyPartName":
     moduleName = MyPartName.TheModuleName
} 

```