### PR TITLE
Some forgotten updates

### DIFF
--- a/GameData/JSI/RasterPropMonitor/RasterPropMonitor.version
+++ b/GameData/JSI/RasterPropMonitor/RasterPropMonitor.version
@@ -6,12 +6,12 @@
   {
     "MAJOR": 0,
     "MINOR": 30,
-    "PATCH": 5
+    "PATCH": 6
   },
   "KSP_VERSION":
   {
     "MAJOR": 1,
-    "MINOR": 5,
+    "MINOR": 6,
     "PATCH": 0
   },
   "KSP_VERSION_MIN":
@@ -23,7 +23,7 @@
   "KSP_VERSION_MAX":
   {
     "MAJOR": 1,
-    "MINOR": 5,
+    "MINOR": 6,
     "PATCH": 99
   }
 }

--- a/RasterPropMonitor.sln
+++ b/RasterPropMonitor.sln
@@ -195,6 +195,6 @@ Global
 		$36.inheritsSet = Mono
 		$36.inheritsScope = text/plain
 		$36.scope = text/plain
-		version = 0.30.5
+		version = 0.30.6
 	EndGlobalSection
 EndGlobal

--- a/RasterPropMonitor/Auxiliary modules/JSIActionGroupSwitch.cs
+++ b/RasterPropMonitor/Auxiliary modules/JSIActionGroupSwitch.cs
@@ -784,8 +784,8 @@ namespace JSI
 
             if (consumingWhileActive && currentState && !forcedShutdown)
             {
-                float requesting = (consumeWhileActiveAmount * TimeWarp.deltaTime);
-                float extracted = part.RequestResource(consumeWhileActiveName, requesting);
+                double requesting = (consumeWhileActiveAmount * TimeWarp.deltaTime);
+                double extracted = part.RequestResource(consumeWhileActiveName, requesting);
                 if (Math.Abs(extracted - requesting) > Math.Abs(requesting / 2))
                 {
                     // We don't have enough of the resource or can't produce more negative resource, so we should shut down...
@@ -893,7 +893,7 @@ namespace JSI
                 // If we're consuming resources on toggle, do that now.
                 if ((consumingOnToggleUp && newState) || (consumingOnToggleDown && !newState))
                 {
-                    float extracted = part.RequestResource(consumeOnToggleName, consumeOnToggleAmount);
+                    double extracted = part.RequestResource(consumeOnToggleName, (double)consumeOnToggleAmount);
                     if (Math.Abs(extracted - consumeOnToggleAmount) > Math.Abs(consumeOnToggleAmount / 2))
                     {
                         // We don't have enough of the resource, so we force a shutdown on the next loop.

--- a/RasterPropMonitor/Auxiliary modules/JSIRadar.cs
+++ b/RasterPropMonitor/Auxiliary modules/JSIRadar.cs
@@ -160,9 +160,9 @@ namespace JSI
                 // Resources check
                 if (resourceAmount > 0.0f)
                 {
-                    float requested = resourceAmount * TimeWarp.fixedDeltaTime;
-                    float supplied = part.RequestResource(resourceId, requested);
-                    if (supplied < requested * 0.5f)
+                    double requested = resourceAmount * TimeWarp.fixedDeltaTime;
+                    double supplied = part.RequestResource(resourceId, requested);
+                    if (supplied < requested * 0.5)
                     {
                         powered = false;
                     }

--- a/RasterPropMonitor/Auxiliary modules/JSIVariableAnimator.cs
+++ b/RasterPropMonitor/Auxiliary modules/JSIVariableAnimator.cs
@@ -661,11 +661,11 @@ namespace JSI
 
             if (resourceAmount > 0.0f)
             {
-                float requesting = (resourceAmount * TimeWarp.deltaTime);
-                if (requesting > 0.0f)
+                double requesting = (resourceAmount * TimeWarp.deltaTime);
+                if (requesting > 0.0)
                 {
-                    float extracted = part.RequestResource(resourceName, requesting);
-                    if (extracted < 0.5f * requesting)
+                    double extracted = part.RequestResource(resourceName, requesting);
+                    if (extracted < 0.5 * requesting)
                     {
                         // Insufficient power - shut down
                         TurnOff(universalTime, true);

--- a/RasterPropMonitor/Handlers/JSISteerableCamera.cs
+++ b/RasterPropMonitor/Handlers/JSISteerableCamera.cs
@@ -160,7 +160,7 @@ namespace JSI
         private Vector2 GetNormalizedScreenPosition(SteerableCameraParameters activeCamera, Vector3 directionVector, float cameraAspect)
         {
             // Transform direction using the active camera's rotation.
-            var targetTransformed = cameraObject.CameraRotation(activeCamera.currentYaw, -activeCamera.currentPitch).Inverse() * directionVector;
+            var targetTransformed = Quaternion.Inverse(cameraObject.CameraRotation(activeCamera.currentYaw, -activeCamera.currentPitch)) * directionVector;
 
             // (x, y) provided the lateral displacement.  (z) provides the "in front of / behind"
             var targetDisp = new Vector2(targetTransformed.x, -targetTransformed.y);

--- a/RasterPropMonitor/RasterPropMonitor.csproj
+++ b/RasterPropMonitor/RasterPropMonitor.csproj
@@ -40,27 +40,16 @@
     </DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="KSPAssets">
-      <HintPath>..\..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\KSPAssets.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="UnityEngine">
+      <HintPath>..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.UI.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 // Revision number is altered automatically.
-[assembly: AssemblyVersion("0.30.5.*")]
+[assembly: AssemblyVersion("0.30.6.*")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.


### PR DESCRIPTION
Change RequestResource to use doubles (float version is marked obsolete).  Change steerable camera transform.  Fix references to point at x64 assemblies, since the x86 assemblies are no more.